### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "python3"
+run = ""

--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
 # PythonInitials
 Learing Python from scratch - 0 to Mastery
+[![Run on Repl.it](https://repl.it/badge/github/ArunKumar143/PythonInitials)](https://repl.it/github/ArunKumar143/PythonInitials)


### PR DESCRIPTION
This pull request configures this repository to be run on Repl.it.      It adds a `.replit` configuration file and a Repl.it badge to the `README`.
     You can read more about running repos on Repl.it [here](https://docs.repl.it/repls/dot-replit), or view the Repl [here](https://repl.it/@ArunKumar1431/PythonInitials).